### PR TITLE
Automatically inject marketable as part of installation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github:[excid3]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -57,19 +57,12 @@ Devise will now automatically create 2 cookies for your users, the referring_url
 
 That's it. You now have some very powerful data: where your best customers come from, what traffic sources are your most lucrative, what on your website converts the best, what people are most interested in, etc. 
 
-P.S. [**I'd love to meet you on Twitter: here**](http://twitter.com/natekontny). 
-
-<iframe src="https://draftin.com/share_buttons/new.html?url=http%3A%2F%2Fninjasandrobots.com%2Fmarketable-for-devise&title=Marketable%20for%20Devise" scrolling="no" frameborder="0" style="border:none; overflow:hidden;width:800px; height:21px; padding-left:50px" allowtransparency="true" ></iframe>
-
-
 ---------------
 
 Feedback
 --------
-[Source code available on Github](https://github.com/n8/devise_marketable). Feedback and pull requests are greatly appreciated.  Let me know if I can improve this.
+[Source code available on Github](https://github.com/excid3/devise_marketable). Feedback and pull requests are greatly appreciated.  Let me know if I can improve this.
 
 ---------------
 
 [Here's a great short presentation from Mike on tracking user metrics](http://vimeo.com/10733370).
-
-<iframe src="//player.vimeo.com/video/10733370" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ I created Marketable to automatically track the most basic and important marketi
 
 1) Add 'devise_marketable' to your Gemfile. 
 
+```ruby
+source "https://rubygems.pkg.github.com/excid3" do
+  gem "devise_marketable", "~> 1.0"
+end
+```
+
+Or from the master branch:
+
 ```
 gem 'devise_marketable', git: 'https://github.com/excid3/devise_marketable'
 ```

--- a/README.md
+++ b/README.md
@@ -49,13 +49,7 @@ rails g devise_marketable User
 rake db:migrate
 ```
 
-5) Make your devise model "marketable"
-
-```
-devise :database_authenticatable, ..., :marketable
-```
-
-6) Restart your server
+5) Restart your server
 
 ------------
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ I created Marketable to automatically track the most basic and important marketi
 1) Add 'devise_marketable' to your Gemfile. 
 
 ```
-gem 'devise_marketable'
+gem 'devise_marketable', git: 'https://github.com/excid3/devise_marketable'
 ```
 
 2) Run `bundle install`

--- a/devise_marketable.gemspec
+++ b/devise_marketable.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency "devise"
+  spec.add_runtime_dependency 'devise', '>= 4.0.0'
 end

--- a/lib/devise_marketable.rb
+++ b/lib/devise_marketable.rb
@@ -7,9 +7,9 @@ module DeviseMarketable
 
   module Controller
     extend ActiveSupport::Concern
-    
+
     included do
-      before_filter :set_tracking_cookies
+      before_action :set_tracking_cookies
     end
 
     def set_tracking_cookies
@@ -54,4 +54,3 @@ module DeviseMarketable
   end
 
 end
-

--- a/lib/generators/devise_marketable/devise_marketable_generator.rb
+++ b/lib/generators/devise_marketable/devise_marketable_generator.rb
@@ -27,5 +27,10 @@ class DeviseMarketableGenerator < Rails::Generators::NamedBase
     migration_template 'migration.rb', "db/migrate/devise_add_marketable_#{name.downcase}.rb"
   end
 
+  def inject_devise_invitable_content
+    path = File.join("app", "models", "#{file_path}.rb")
+    inject_into_file(path, "marketable, :", :after => "devise :") if File.exists?(path)
+  end
+
   protected
 end

--- a/lib/generators/devise_marketable/devise_marketable_generator.rb
+++ b/lib/generators/devise_marketable/devise_marketable_generator.rb
@@ -24,7 +24,7 @@ class DeviseMarketableGenerator < Rails::Generators::NamedBase
 
 
   def create_migration_file
-    migration_template 'migration.rb', "db/migrate/devise_add_marketable_#{name.downcase}.rb"
+    migration_template 'migration.rb', "db/migrate/devise_add_marketable_#{name.underscore}.rb"
   end
 
   def inject_devise_invitable_content


### PR DESCRIPTION
Here's that pull request I mentioned to you on Twitter a week or two ago! :+1:

Automatically injects the `:marketable` setting into the model so you can remove a whole step of the installation process.
