### PR TITLE
Fix deprecation warning on Rails5

### DIFF
--- a/devise_marketable.gemspec
+++ b/devise_marketable.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency "devise"
+  spec.add_runtime_dependency 'devise', '>= 4.0.0'
 end

--- a/lib/devise_marketable.rb
+++ b/lib/devise_marketable.rb
@@ -7,9 +7,9 @@ module DeviseMarketable
 
   module Controller
     extend ActiveSupport::Concern
-    
+
     included do
-      before_filter :set_tracking_cookies
+      before_action :set_tracking_cookies
     end
 
     def set_tracking_cookies
@@ -54,4 +54,3 @@ module DeviseMarketable
   end
 
 end
-


### PR DESCRIPTION
```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.
```
